### PR TITLE
Add SQLite database manager with migration support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore SQLite database files
+*.db
+*/__pycache__/
+*.pyc

--- a/db/migrations/0001_initial_schema.sql
+++ b/db/migrations/0001_initial_schema.sql
@@ -1,0 +1,75 @@
+CREATE TABLE exercises (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    description TEXT,
+    muscle_group TEXT
+);
+
+CREATE TABLE clients (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL UNIQUE,
+    joined_on TEXT NOT NULL
+);
+
+CREATE TABLE sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    client_id INTEGER NOT NULL,
+    session_date TEXT NOT NULL,
+    notes TEXT,
+    FOREIGN KEY (client_id) REFERENCES clients(id) ON DELETE CASCADE
+);
+
+CREATE TABLE session_exercises (
+    session_id INTEGER NOT NULL,
+    exercise_id INTEGER NOT NULL,
+    sets INTEGER NOT NULL CHECK (sets > 0),
+    repetitions INTEGER NOT NULL CHECK (repetitions > 0),
+    weight REAL CHECK (weight >= 0),
+    PRIMARY KEY (session_id, exercise_id),
+    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE,
+    FOREIGN KEY (exercise_id) REFERENCES exercises(id)
+);
+
+CREATE TABLE nutrition_profiles (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    client_id INTEGER NOT NULL,
+    calories_target INTEGER CHECK (calories_target > 0),
+    protein_target REAL CHECK (protein_target >= 0),
+    carbs_target REAL CHECK (carbs_target >= 0),
+    fats_target REAL CHECK (fats_target >= 0),
+    FOREIGN KEY (client_id) REFERENCES clients(id) ON DELETE CASCADE
+);
+
+CREATE TABLE foods (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    calories INTEGER NOT NULL CHECK (calories >= 0),
+    protein REAL NOT NULL CHECK (protein >= 0),
+    carbs REAL NOT NULL CHECK (carbs >= 0),
+    fats REAL NOT NULL CHECK (fats >= 0)
+);
+
+CREATE TABLE invoices (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    client_id INTEGER NOT NULL,
+    amount REAL NOT NULL CHECK (amount >= 0),
+    issued_on TEXT NOT NULL,
+    paid INTEGER NOT NULL DEFAULT 0 CHECK (paid IN (0, 1)),
+    FOREIGN KEY (client_id) REFERENCES clients(id) ON DELETE CASCADE
+);
+
+CREATE TABLE calendar (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    client_id INTEGER,
+    event_date TEXT NOT NULL,
+    description TEXT,
+    FOREIGN KEY (client_id) REFERENCES clients(id) ON DELETE SET NULL
+);
+
+CREATE TABLE app_logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    level TEXT NOT NULL CHECK (level IN ('INFO', 'WARNING', 'ERROR')),
+    message TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/services/db_manager.py
+++ b/services/db_manager.py
@@ -1,0 +1,103 @@
+"""SQLite database manager with migration support."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Iterator
+
+
+class DBManager:
+    """Singleton service managing SQLite connection and migrations."""
+
+    _instance: DBManager | None = None
+
+    def __init__(self) -> None:
+        self.db_path = Path("db/app.db")
+        self.migrations_path = Path("db/migrations")
+        self.conn = self._connect()
+        self._apply_migrations()
+        self._verify_integrity()
+
+    @classmethod
+    def get_instance(cls) -> "DBManager":
+        """Return the single :class:`DBManager` instance."""
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def _connect(self) -> sqlite3.Connection:
+        """Create a SQLite connection with WAL mode enabled.
+
+        The database file is created if missing. If the file exists but is
+        corrupt, it is removed and recreated to avoid application crashes.
+        """
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.migrations_path.mkdir(parents=True, exist_ok=True)
+
+        need_init = False
+        if self.db_path.exists():
+            try:
+                tmp_conn = sqlite3.connect(self.db_path)
+                status = tmp_conn.execute("PRAGMA integrity_check").fetchone()[0]
+                tmp_conn.close()
+                if status.lower() != "ok":
+                    need_init = True
+            except sqlite3.DatabaseError:
+                need_init = True
+        else:
+            need_init = True
+
+        if need_init and self.db_path.exists():
+            self.db_path.unlink()
+
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute("PRAGMA foreign_keys=ON;")
+        return conn
+
+    def _apply_migrations(self) -> None:
+        """Apply pending SQL migrations from ``db/migrations`` directory."""
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                version INTEGER PRIMARY KEY,
+                applied_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        row = self.conn.execute("SELECT MAX(version) FROM schema_migrations").fetchone()
+        current_version = row[0] if row[0] is not None else 0
+
+        for path in self._migration_files():
+            version = int(path.stem.split("_", 1)[0])
+            if version > current_version:
+                script = path.read_text()
+                try:
+                    self.conn.execute("BEGIN")
+                    self.conn.executescript(script)
+                    self.conn.execute(
+                        "INSERT INTO schema_migrations (version) VALUES (?)",
+                        (version,),
+                    )
+                    self.conn.commit()
+                    current_version = version
+                except sqlite3.Error as exc:
+                    self.conn.rollback()
+                    raise exc
+
+    def _migration_files(self) -> Iterator[Path]:
+        """Yield migration files ordered by their version prefix."""
+        return iter(sorted(self.migrations_path.glob("*.sql")))
+
+    def _verify_integrity(self) -> None:
+        """Run SQLite integrity check to ensure database is valid."""
+        result = self.conn.execute("PRAGMA integrity_check").fetchone()[0]
+        if result.lower() != "ok":  # pragma: no cover - defensive programming
+            raise sqlite3.DatabaseError(f"Integrity check failed: {result}")
+
+    def get_connection(self) -> sqlite3.Connection:
+        """Return the active SQLite connection."""
+        return self.conn
+
+
+__all__ = ["DBManager"]


### PR DESCRIPTION
## Summary
- introduce DBManager singleton handling SQLite connections and migrations
- add WAL-enabled initialization with integrity checks
- define initial database schema migration

## Testing
- `python -m py_compile services/db_manager.py`
- `python - <<'PY'
from services.db_manager import DBManager

db = DBManager.get_instance()
conn = db.get_connection()
print('version', conn.execute('SELECT MAX(version) FROM schema_migrations').fetchone()[0])
print('journal_mode', conn.execute('PRAGMA journal_mode').fetchone()[0])
print('integrity', conn.execute('PRAGMA integrity_check').fetchone()[0])
PY`
- `python - <<'PY'
from services.db_manager import DBManager

# simulate new migration
open('db/migrations/0002_test.sql','w').write('CREATE TABLE test_table (id INTEGER PRIMARY KEY);')
db = DBManager.get_instance()
getattr(db, '_apply_migrations')()
conn = db.get_connection()
print('version:', conn.execute('SELECT MAX(version) FROM schema_migrations').fetchone()[0])
print('has_test_table:', bool(conn.execute("SELECT name FROM sqlite_master WHERE type=""table"" AND name=""test_table"").fetchone()))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68adcfb60d14832a8acbea186fa214a9