### PR TITLE
Add exercise search and filtering with centralized state

### DIFF
--- a/config/enums.py
+++ b/config/enums.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Enumerations and label mappings for exercises."""
+
+from enum import Enum
+
+
+class PrimaryMuscle(Enum):
+    PECTORAUX = "Pectoraux"
+    DORSAUX = "Dorsaux"
+    EPAULES = "Épaules"
+    BICEPS = "Biceps"
+    TRICEPS = "Triceps"
+    TRAPEZES = "Trapèzes"
+    LOMBAIRES = "Lombaires"
+    ABDOMINAUX = "Abdominaux"
+    OBLIQUES = "Obliques"
+    QUADRICEPS = "Quadriceps"
+    ISCHIO_JAMBIERS = "Ischio-jambiers"
+    FESSIERS = "Fessiers"
+    MOLLETS = "Mollets"
+    AVANT_BRAS = "Avant-bras"
+    COU = "Cou"
+    CORPS_ENTIER = "Corps entier"
+
+
+class Equipment(Enum):
+    BAR = "Barre"
+    DB = "Haltères"
+    KB = "Kettlebell"
+    CBL = "Poulie/Câble"
+    MACH = "Machine guidée"
+    SMITH = "Smith"
+    BAND = "Élastiques"
+    TRX = "TRX/Anneaux"
+    BW = "Poids du corps"
+    BENCH = "Banc/Step/Box"
+    SBALL = "Swiss Ball"
+    MBALL = "Médecine ball"
+    SLED = "Sled/Prowler"
+
+
+class MovementPattern(Enum):
+    SQUAT = "Squat"
+    HINGE = "Hinge"
+    LUNGE = "Fente"
+    PH = "Push horizontal"
+    PV = "Push vertical"
+    RH = "Tirage horizontal"
+    RV = "Tirage vertical"
+    CORE_AEXT = "Gainage"
+    CORE_AROT = "Anti-rotation"
+    CORE_ROT = "Rotation"
+    LOCO = "Locomotion/Carry"
+    PLYO = "Saut/Pliométrie"
+    COND = "Conditioning"
+    MOB = "Mobilité"
+
+
+PRIMARY_MUSCLE_LABELS = {e.name: e.value for e in PrimaryMuscle}
+PRIMARY_MUSCLE_CODES = {e.value: e.name for e in PrimaryMuscle}
+
+EQUIPMENT_LABELS = {e.name: e.value for e in Equipment}
+EQUIPMENT_CODES = {e.value: e.name for e in Equipment}
+
+PATTERN_LABELS = {e.name: e.value for e in MovementPattern}
+PATTERN_CODES = {e.value: e.name for e in MovementPattern}
+
+
+__all__ = [
+    "PrimaryMuscle",
+    "Equipment",
+    "MovementPattern",
+    "PRIMARY_MUSCLE_LABELS",
+    "PRIMARY_MUSCLE_CODES",
+    "EQUIPMENT_LABELS",
+    "EQUIPMENT_CODES",
+    "PATTERN_LABELS",
+    "PATTERN_CODES",
+]
+

--- a/services/exercises_service.py
+++ b/services/exercises_service.py
@@ -8,22 +8,15 @@ from typing import Dict, List, Optional
 
 from models.exercise import Exercise
 from repositories.exercises_repository import ExercisesRepository
+from config.enums import (
+    PRIMARY_MUSCLE_LABELS,
+    EQUIPMENT_LABELS,
+    PATTERN_LABELS,
+)
 
-PRIMARY_MUSCLES = {
-    'Pectoraux','Dorsaux','Épaules','Biceps','Triceps','Trapèzes','Lombaires',
-    'Abdominaux','Obliques','Quadriceps','Ischio-jambiers','Fessiers','Mollets',
-    'Avant-bras','Cou','Corps entier'
-}
-EQUIPMENTS = {
-    'Barre','Haltères','Kettlebell','Poulie/Câble','Machine guidée','Smith',
-    'Élastiques','TRX/Anneaux','Poids du corps','Banc/Step/Box','Swiss Ball',
-    'Médecine ball','Sled/Prowler'
-}
-PATTERNS = {
-    'Squat','Hinge','Fente','Push horizontal','Push vertical','Tirage horizontal',
-    'Tirage vertical','Gainage','Anti-rotation','Rotation','Locomotion/Carry',
-    'Saut/Pliométrie','Conditioning','Mobilité'
-}
+PRIMARY_MUSCLES = set(PRIMARY_MUSCLE_LABELS.keys())
+EQUIPMENTS = set(EQUIPMENT_LABELS.keys())
+PATTERNS = set(PATTERN_LABELS.keys())
 
 
 class ExercisesService:
@@ -95,6 +88,26 @@ class ExercisesService:
             name=filters.get('name'),
             primary_muscle=filters.get('primary_muscle'),
             equipment=filters.get('equipment'),
+        )
+
+    def search(
+        self,
+        query: str = "",
+        *,
+        primary_muscles: Optional[List[str]] = None,
+        equipment: Optional[List[str]] = None,
+        patterns: Optional[List[str]] = None,
+        difficulty: tuple[int, int] | None = None,
+        include_inactive: bool = False,
+    ) -> List[Exercise]:
+        """Search exercises using query and filters."""
+        return self.repo.search(
+            query=query,
+            primary_muscles=primary_muscles or [],
+            equipment=equipment or [],
+            patterns=patterns or [],
+            difficulty=difficulty,
+            include_inactive=include_inactive,
         )
 
     def soft_delete(self, exercise_id: str) -> None:

--- a/services/store.py
+++ b/services/store.py
@@ -1,16 +1,38 @@
 """Global observable store for application state."""
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import Callable, Generic, List, TypeVar
 
 T = TypeVar("T")
 
 
 @dataclass(frozen=True)
+class ExerciseFilters:
+    """Filters applied to exercise listings."""
+
+    primary_muscles: List[str] = field(default_factory=list)
+    equipment: List[str] = field(default_factory=list)
+    patterns: List[str] = field(default_factory=list)
+    difficulty_min: int = 1
+    difficulty_max: int = 5
+
+
+@dataclass(frozen=True)
+class ExercisesState:
+    """State related to exercises catalogue."""
+
+    search_query: str = ""
+    active_filters: ExerciseFilters = field(default_factory=ExerciseFilters)
+    include_inactive: bool = False
+
+
+@dataclass(frozen=True)
 class AppState:
     """Immutable application state."""
+
     route: str = "home"
+    exercises: ExercisesState = field(default_factory=ExercisesState)
 
 
 class Store(Generic[T]):

--- a/tests/test_exercise_search.py
+++ b/tests/test_exercise_search.py
@@ -1,0 +1,47 @@
+import sqlite3
+import time
+import uuid
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from models.exercise import Exercise
+from repositories.exercises_repository import ExercisesRepository
+
+
+def setup_db(count: int = 0) -> ExercisesRepository:
+    conn = sqlite3.connect(":memory:")
+    with open("db/migrations/0002_create_exercises_table.sql", "r", encoding="utf-8") as f:
+        conn.executescript(f.read())
+    repo = ExercisesRepository(conn)
+    for i in range(count):
+        ex = Exercise(
+            id=str(uuid.uuid4()),
+            name=f"Exercice {i}",
+            slug=f"ex{i}",
+            primary_muscle="PECTORAUX",
+            equipment="BAR",
+            pattern="PH",
+            difficulty=3,
+        )
+        repo.create(ex)
+    return repo
+
+
+def test_search_filters():
+    repo = setup_db(5)
+    res = repo.search(query="Exercice 1", primary_muscles=["PECTORAUX"], equipment=["BAR"], patterns=["PH"], difficulty=(1,5))
+    assert res and res[0].name == "Exercice 1"
+    res = repo.search(query="Inexistant")
+    assert res == []
+
+
+def test_search_performance():
+    repo = setup_db(1000)
+    start = time.perf_counter()
+    repo.search(query="Exercice", primary_muscles=["PECTORAUX"], equipment=["BAR"], difficulty=(1,5))
+    elapsed = (time.perf_counter() - start) * 1000
+    assert elapsed < 150

--- a/tests/test_exercises_repository.py
+++ b/tests/test_exercises_repository.py
@@ -19,7 +19,7 @@ def setup_db() -> sqlite3.Connection:
 def test_create_and_get_by_id():
     conn = setup_db()
     repo = ExercisesRepository(conn)
-    ex = Exercise(id=str(uuid.uuid4()), name="Pompe", slug="pompe", primary_muscle="Pectoraux")
+    ex = Exercise(id=str(uuid.uuid4()), name="Pompe", slug="pompe", primary_muscle="PECTORAUX")
     repo.create(ex)
     fetched = repo.get_by_id(ex.id)
     assert fetched is not None
@@ -30,12 +30,18 @@ def test_create_and_get_by_id():
 def test_list_and_update_and_soft_delete():
     conn = setup_db()
     repo = ExercisesRepository(conn)
-    ex1 = Exercise(id="1", name="Squat", slug="squat", primary_muscle="Quadriceps", equipment="Barre")
-    ex2 = Exercise(id="2", name="Traction", slug="traction", primary_muscle="Dorsaux", equipment="Poids du corps")
+    ex1 = Exercise(id="1", name="Squat", slug="squat", primary_muscle="QUADRICEPS", equipment="BAR")
+    ex2 = Exercise(
+        id="2",
+        name="Traction",
+        slug="traction",
+        primary_muscle="DORSAUX",
+        equipment="BW",
+    )
     repo.create(ex1)
     repo.create(ex2)
     # list filter
-    res = repo.list_all(name="Squat", primary_muscle="Quadriceps", equipment="Barre")
+    res = repo.list_all(name="Squat", primary_muscle="QUADRICEPS", equipment="BAR")
     assert len(res) == 1 and res[0].id == "1"
     assert repo.get_by_name("Traction").id == "2"
     # update
@@ -52,7 +58,7 @@ def test_is_used_in_session():
     conn = setup_db()
     repo = ExercisesRepository(conn)
     ex_id = "ex-1"
-    ex = Exercise(id=ex_id, name="Crunch", slug="crunch", primary_muscle="Abdominaux")
+    ex = Exercise(id=ex_id, name="Crunch", slug="crunch", primary_muscle="ABDOMINAUX")
     repo.create(ex)
     conn.execute(
         "INSERT INTO session_exercises (session_id, exercise_id, sets, repetitions) VALUES (1, ?, 3, 10)",

--- a/tests/test_exercises_service.py
+++ b/tests/test_exercises_service.py
@@ -13,10 +13,10 @@ from services.exercises_service import ExercisesService
 def valid_data():
     return {
         'name': 'Développé couché',
-        'primary_muscle': 'Pectoraux',
-        'secondary_muscles': ['Triceps'],
-        'equipment': 'Barre',
-        'pattern': 'Push horizontal',
+        'primary_muscle': 'PECTORAUX',
+        'secondary_muscles': ['TRICEPS'],
+        'equipment': 'BAR',
+        'pattern': 'PH',
         'difficulty': 3,
         'rpe_default': 7.5,
         'rest_s_default': 120,
@@ -34,7 +34,7 @@ def test_create_success_and_slug():
 
 def test_create_duplicate_name():
     repo = MagicMock()
-    repo.get_by_name.return_value = Exercise(id='1', name='x', slug='x', primary_muscle='Pectoraux')
+    repo.get_by_name.return_value = Exercise(id='1', name='x', slug='x', primary_muscle='PECTORAUX')
     service = ExercisesService(repo)
     with pytest.raises(ValueError):
         service.create(valid_data())
@@ -49,15 +49,15 @@ def test_validation_errors():
     with pytest.raises(ValueError):
         service.create(bad)
     bad = valid_data()
-    bad['primary_muscle'] = 'Invalide'
+    bad['primary_muscle'] = 'INVALID'
     with pytest.raises(ValueError):
         service.create(bad)
     bad = valid_data()
-    bad['equipment'] = 'Invalide'
+    bad['equipment'] = 'INVALID'
     with pytest.raises(ValueError):
         service.create(bad)
     bad = valid_data()
-    bad['pattern'] = 'Invalid'
+    bad['pattern'] = 'INVALID'
     with pytest.raises(ValueError):
         service.create(bad)
     bad = valid_data()
@@ -69,21 +69,21 @@ def test_validation_errors():
     with pytest.raises(ValueError):
         service.create(bad)
     bad = valid_data()
-    bad['secondary_muscles'] = 'Triceps'
+    bad['secondary_muscles'] = 'TRICEPS'
     with pytest.raises(ValueError):
         service.create(bad)
 
 
 def test_update_and_soft_delete():
     repo = MagicMock()
-    existing = Exercise(id='1', name='Old', slug='old', primary_muscle='Pectoraux')
+    existing = Exercise(id='1', name='Old', slug='old', primary_muscle='PECTORAUX')
     repo.get_by_id.side_effect = [existing, existing, None]
     repo.get_by_name.return_value = None
     service = ExercisesService(repo)
     updated = service.update('1', {'name': 'Nouveau', 'difficulty': 4})
     assert updated.name == 'Nouveau'
     repo.update.assert_called_once()
-    repo.get_by_name.return_value = Exercise(id='2', name='Nouveau', slug='n', primary_muscle='Pectoraux')
+    repo.get_by_name.return_value = Exercise(id='2', name='Nouveau', slug='n', primary_muscle='PECTORAUX')
     with pytest.raises(ValueError):
         service.update('1', {'name': 'Nouveau'})
     with pytest.raises(ValueError):

--- a/ui/pages/exercises.py
+++ b/ui/pages/exercises.py
@@ -3,17 +3,58 @@ from __future__ import annotations
 
 import customtkinter as ctk
 
+from config.enums import PRIMARY_MUSCLE_LABELS
+from services.exercises_service import ExercisesService
 from services.store import AppState, Store
 from ui.base_page import BasePage
+from ui.widgets.exercise_filters import ExerciseFiltersWidget
 
 
 class ExercisesPage(BasePage):
     """Placeholder for exercises page."""
 
-    def __init__(self, master: ctk.CTkFrame, router, store: Store[AppState], **kwargs) -> None:
+    def __init__(
+        self,
+        master: ctk.CTkFrame,
+        router,
+        store: Store[AppState],
+        service: ExercisesService,
+        **kwargs,
+    ) -> None:
         super().__init__(master, router, store, **kwargs)
-        ctk.CTkLabel(self, text="Exercices").pack(padx=20, pady=20)
+        self.service = service
+        self.store.subscribe(self._on_state_change)
+
+        self.filters = ExerciseFiltersWidget(self, store)
+        self.filters.pack(side="left", fill="y")
+
+        self.list_frame = ctk.CTkScrollableFrame(self)
+        self.list_frame.pack(side="right", fill="both", expand=True)
+
+        self._on_state_change(self.store.get_state())
 
     @property
     def breadcrumb(self) -> list[str]:
         return ["Exercices"]
+
+    def _on_state_change(self, state: AppState) -> None:
+        ex_state = state.exercises
+        results = self.service.search(
+            query=ex_state.search_query,
+            primary_muscles=ex_state.active_filters.primary_muscles,
+            equipment=ex_state.active_filters.equipment,
+            patterns=ex_state.active_filters.patterns,
+            difficulty=(
+                ex_state.active_filters.difficulty_min,
+                ex_state.active_filters.difficulty_max,
+            ),
+            include_inactive=ex_state.include_inactive,
+        )
+        for widget in self.list_frame.winfo_children():
+            widget.destroy()
+        if not results:
+            ctk.CTkLabel(self.list_frame, text="Aucun résultat").pack(padx=20, pady=20)
+            return
+        for ex in results:
+            label = f"{ex.name} - {PRIMARY_MUSCLE_LABELS.get(ex.primary_muscle, ex.primary_muscle)}"
+            ctk.CTkLabel(self.list_frame, text=label).pack(anchor="w", padx=10, pady=2)

--- a/ui/widgets/exercise_filters.py
+++ b/ui/widgets/exercise_filters.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+"""Widget encapsulating search and filter controls for exercises."""
+
+import tkinter as tk
+import customtkinter as ctk
+
+from config.enums import (
+    PRIMARY_MUSCLE_LABELS,
+    EQUIPMENT_LABELS,
+    PATTERN_LABELS,
+)
+from services.store import Store, AppState, ExerciseFilters, ExercisesState
+
+
+class ExerciseFiltersWidget(ctk.CTkFrame):
+    """UI widget allowing user to search and filter exercises."""
+
+    def __init__(self, master: ctk.CTkFrame, store: Store[AppState], **kwargs) -> None:
+        super().__init__(master, **kwargs)
+        self.store = store
+
+        self.search_var = tk.StringVar()
+        search_entry = ctk.CTkEntry(self, textvariable=self.search_var)
+        search_entry.pack(fill="x", padx=5, pady=5)
+        search_entry.bind("<KeyRelease>", self._on_change)
+
+        # Checkboxes for primary muscles
+        self.primary_vars: dict[str, tk.BooleanVar] = {}
+        pm_frame = ctk.CTkScrollableFrame(self, height=120)
+        pm_frame.pack(fill="x", padx=5, pady=5)
+        for code, label in PRIMARY_MUSCLE_LABELS.items():
+            var = tk.BooleanVar()
+            self.primary_vars[code] = var
+            ctk.CTkCheckBox(pm_frame, text=label, variable=var, command=self._on_change).pack(anchor="w")
+
+        # Equipment checkboxes
+        self.equipment_vars: dict[str, tk.BooleanVar] = {}
+        eq_frame = ctk.CTkScrollableFrame(self, height=80)
+        eq_frame.pack(fill="x", padx=5, pady=5)
+        for code, label in EQUIPMENT_LABELS.items():
+            var = tk.BooleanVar()
+            self.equipment_vars[code] = var
+            ctk.CTkCheckBox(eq_frame, text=label, variable=var, command=self._on_change).pack(anchor="w")
+
+        # Pattern checkboxes
+        self.pattern_vars: dict[str, tk.BooleanVar] = {}
+        pat_frame = ctk.CTkScrollableFrame(self, height=80)
+        pat_frame.pack(fill="x", padx=5, pady=5)
+        for code, label in PATTERN_LABELS.items():
+            var = tk.BooleanVar()
+            self.pattern_vars[code] = var
+            ctk.CTkCheckBox(pat_frame, text=label, variable=var, command=self._on_change).pack(anchor="w")
+
+        # Difficulty sliders
+        self.diff_min = tk.IntVar(value=1)
+        self.diff_max = tk.IntVar(value=5)
+        diff_frame = ctk.CTkFrame(self)
+        diff_frame.pack(fill="x", padx=5, pady=5)
+        ctk.CTkLabel(diff_frame, text="Difficulté").pack(anchor="w")
+        ctk.CTkSlider(diff_frame, from_=1, to=5, variable=self.diff_min, command=lambda v: self._on_change()).pack(fill="x")
+        ctk.CTkSlider(diff_frame, from_=1, to=5, variable=self.diff_max, command=lambda v: self._on_change()).pack(fill="x")
+
+        # Include inactive
+        self.inactive_var = tk.BooleanVar()
+        ctk.CTkCheckBox(self, text="Inclure les inactifs", variable=self.inactive_var, command=self._on_change).pack(anchor="w", padx=5, pady=5)
+
+    def _on_change(self, event: tk.Event | None = None) -> None:
+        filters = ExerciseFilters(
+            primary_muscles=[code for code, var in self.primary_vars.items() if var.get()],
+            equipment=[code for code, var in self.equipment_vars.items() if var.get()],
+            patterns=[code for code, var in self.pattern_vars.items() if var.get()],
+            difficulty_min=self.diff_min.get(),
+            difficulty_max=self.diff_max.get(),
+        )
+        new_state = ExercisesState(
+            search_query=self.search_var.get(),
+            active_filters=filters,
+            include_inactive=self.inactive_var.get(),
+        )
+        self.store.update(exercises=new_state)
+
+
+__all__ = ["ExerciseFiltersWidget"]


### PR DESCRIPTION
## Summary
- add data dictionary enums for muscles, equipment and patterns
- implement repository and service search/filter logic using normalized queries
- extend store and UI with filter widgets and live exercise list

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ade964d3c0832aafa69c3f0e08c679